### PR TITLE
Replaced dead link with a cached version

### DIFF
--- a/themes/default/edit.php
+++ b/themes/default/edit.php
@@ -49,7 +49,7 @@
 					<li><code>%{color:red}Red% text</code> &rarr; <span style='color:red'>Red</span> text</li>
 				</ul>
 				For more markup styles, see the 
-				<a href="http://hobix.com/textile/">Textile reference</a>.
+				<a href="http://redcloth.org/hobix.com/textile/">Textile reference</a>.
 			</p>
 		</div>
 


### PR DESCRIPTION
Textile references pointed to hobix.com which is down.
Cached version here: http://redcloth.org/hobix.com/textile/
More info on disapearence of hobix: http://redcloth.org/hobix.com/